### PR TITLE
Add Nix flake

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,3 @@
 bin/
 .DS_Store
+result

--- a/README.md
+++ b/README.md
@@ -25,6 +25,21 @@ $ brew install foto
 
 Or download the binary from [here](https://github.com/waynezhang/foto/releases)
 
+### Nix/NixOS
+
+for Nix users, a Flake is provided. It can be used to run the application
+directly or add the package to your configuration as flake input.
+
+It also allows to try out foto, without permanent installation.
+
+```sh
+nix run github:waynezhang/foto
+```
+
+Consult the [Nix
+manual](https://nix.dev/manual/nix/2.25/command-ref/new-cli/nix3-flake.html) for
+details.
+
 ### Other platforms
 
 Download the binary from [here](https://github.com/waynezhang/foto/releases)

--- a/flake.lock
+++ b/flake.lock
@@ -1,0 +1,26 @@
+{
+  "nodes": {
+    "nixpkgs": {
+      "locked": {
+        "lastModified": 1732014248,
+        "narHash": "sha256-y/MEyuJ5oBWrWAic/14LaIr/u5E0wRVzyYsouYY3W6w=",
+        "owner": "NixOS",
+        "repo": "nixpkgs",
+        "rev": "23e89b7da85c3640bbc2173fe04f4bd114342367",
+        "type": "github"
+      },
+      "original": {
+        "id": "nixpkgs",
+        "ref": "nixos-unstable",
+        "type": "indirect"
+      }
+    },
+    "root": {
+      "inputs": {
+        "nixpkgs": "nixpkgs"
+      }
+    }
+  },
+  "root": "root",
+  "version": 7
+}

--- a/flake.nix
+++ b/flake.nix
@@ -1,0 +1,61 @@
+{
+  description = "Publishing tool for minimalist photographers";
+
+  # Nixpkgs / NixOS version to use.
+  inputs.nixpkgs.url = "nixpkgs/nixos-unstable";
+
+  outputs =
+    { self, nixpkgs }:
+    let
+
+      # to work with older version of flakes
+      lastModifiedDate = self.lastModifiedDate or self.lastModified or "19700101";
+
+      # Generate a user-friendly version number.
+      version = builtins.substring 0 8 lastModifiedDate;
+
+      # System types to support.
+      supportedSystems = [
+        "x86_64-linux"
+        "x86_64-darwin"
+        "aarch64-linux"
+        "aarch64-darwin"
+      ];
+
+      # Helper function to generate an attrset '{ x86_64-linux = f "x86_64-linux"; ... }'.
+      forAllSystems = nixpkgs.lib.genAttrs supportedSystems;
+
+      # Nixpkgs instantiated for supported system types.
+      nixpkgsFor = forAllSystems (system: import nixpkgs { inherit system; });
+
+    in
+    {
+
+      # Provide some binary packages for selected system types.
+      packages = forAllSystems (
+        system:
+        let
+          pkgs = nixpkgsFor.${system};
+          lib = pkgs.lib;
+        in
+        rec {
+          foto = pkgs.buildGoModule {
+            pname = "foto";
+            inherit version;
+            src = ./.;
+            vendorHash = "sha256-GiCLg/b+ZF5nAXZh/yIH34yyRFPh2LxEKfXiCp929LI=";
+
+            meta = with lib;{
+              homepage = "https://github.com/waynezhang/foto";
+              description = "Yet another publishing tool for minimalist photographers";
+              license = licenses.mit;
+              mainProgram = "foto";
+              maintainers = with maintainers; [ pinpox ];
+            };
+          };
+
+          default = foto;
+        }
+      );
+    };
+}


### PR DESCRIPTION
This PR adds a flake file for Nix users. Apart from simplifying build and installation, it allows running foto from anywhere with Nix installed using:

```sh
nix run github:waynezhang/foto
```

*NOTE*: I personally use NixOS on my machines and find this handy, but fully understand if you have no interest in supporting this. Feel free to close PR if not needed.